### PR TITLE
Update: Contribution form select sense and upload statuses.

### DIFF
--- a/apps/erya/src/app/contribute/contribute.component.html
+++ b/apps/erya/src/app/contribute/contribute.component.html
@@ -33,7 +33,10 @@
           >.
         </p>
         <br />
-        <div class="is-inline-block" *ngIf="(senses$ | async)?.length">
+        <div
+          class="is-inline-block is-fullwidth-er"
+          *ngIf="(senses$ | async)?.length"
+        >
           <form [formGroup]="signFormGroup" (ngSubmit)="onSubmit()">
             <p class="is-size-5 has-text-weight-medium has-text-link">
               Add your video
@@ -63,39 +66,46 @@
               </label>
             </div>
             <br />
-            <br />
-            <p class="title is-size-5 has-text-weight-medium has-text-link">
-              "<span class="is-capitalized">{{ searchString.value }}</span
-              >" has different senses
-            </p>
-            <p class="is-size-6">
-              Select all that apply to your sign
-            </p>
-            <div class="columns is-multiline">
-              <div
-                class="column is-one-third sense-column"
-                *ngFor="let sense of senses$ | async; let i = index"
-                formArrayName="senseIds"
-              >
-                <input
-                  type="checkbox"
-                  class="sense-input"
-                  [formControlName]="i"
-                  [id]="i"
-                />
-                <label class="box" [for]="i">
-                  <span
-                    ><span class="is-capitalized has-text-weight-bold">
-                      {{ sense.oxId | removeUnderscores }} </span
-                    ><span class="has-text-grey has-text-weight-medium">{{
-                      sense.lexicalCategory
-                    }}</span></span
+
+            <div *ngIf="senses$ | async as senses">
+              <div *ngIf="senses.length > 1">
+                <br />
+                <p class="title is-size-5 has-text-weight-medium has-text-link">
+                  "<span class="is-capitalized">{{ searchString.value }}</span
+                  >" has different senses.
+                </p>
+                <p class="is-size-6">
+                  Tick all the senses which apply to this sign.
+                </p>
+                <div class="columns is-multiline">
+                  <div
+                    class="column is-one-third sense-column"
+                    *ngFor="let sense of senses; let i = index"
+                    formArrayName="senseIds"
                   >
-                  <span class="sense-example has-text-grey is-italic"
-                    >‘{{ sense.example }}’</span
-                  >
-                  <span class="sense-definition "> {{ sense.definition }}</span>
-                </label>
+                    <input
+                      type="checkbox"
+                      class="sense-input"
+                      [formControlName]="i"
+                      [id]="i"
+                    />
+                    <label class="box" [for]="i">
+                      <span
+                        ><span class="is-capitalized has-text-weight-bold">
+                          {{ sense.oxId | removeUnderscores }} </span
+                        ><span class="has-text-grey has-text-weight-medium">{{
+                          sense.lexicalCategory
+                        }}</span></span
+                      >
+                      <span class="sense-example has-text-grey is-italic"
+                        >‘{{ sense.example }}’</span
+                      >
+                      <span class="sense-definition ">
+                        {{ sense.definition }}</span
+                      >
+                    </label>
+                  </div>
+                </div>
               </div>
             </div>
             <br />

--- a/apps/erya/src/app/contribute/contribute.component.html
+++ b/apps/erya/src/app/contribute/contribute.component.html
@@ -66,7 +66,6 @@
               </label>
             </div>
             <br />
-
             <div *ngIf="senses$ | async as senses">
               <div *ngIf="senses.length > 1">
                 <br />
@@ -128,16 +127,44 @@
             </p>
             <br />
             <button
-              class="is-pulled-right button is-primary is-fullwidth-mobile is-medium"
+              class="is-pulled-right button is-primary is-fullwidth-mobile is-medium upload-sign-button"
               type="submit"
               [disabled]="signFormGroup.invalid"
+              [ngClass]="{
+                'is-primary':
+                  uploadStatus === 'none' ||
+                  uploadStatus === 'creating' ||
+                  uploadStatus === 'uploading',
+                'is-success': uploadStatus === 'success',
+                'is-danger': uploadStatus === 'error'
+              }"
             >
-              Upload your sign
+              <span class="icon" *ngIf="uploadStatus !== 'none'">
+                <i
+                  *ngIf="
+                    uploadStatus === 'uploading' || uploadStatus === 'creating'
+                  "
+                  class="loader"
+                ></i>
+
+                <fa-icon
+                  *ngIf="uploadStatus === 'success'"
+                  [icon]="['fas', 'check-circle']"
+                ></fa-icon>
+                <fa-icon
+                  *ngIf="uploadStatus === 'error'"
+                  [icon]="['fas', 'exclamation-circle']"
+                ></fa-icon>
+              </span>
+              <span *ngIf="uploadStatus === 'none'">Upload your sign</span>
+              <span *ngIf="uploadStatus === 'uploading'">Uploading...</span>
+              <span *ngIf="uploadStatus === 'creating'">Creating...</span>
+              <span *ngIf="uploadStatus === 'success'">Done! </span>
+              <span *ngIf="uploadStatus === 'error'">Something goes wrong</span>
             </button>
           </form>
         </div>
       </div>
     </div>
   </div>
-  Upload status: {{ uploadStatus }}
 </section>

--- a/apps/erya/src/app/contribute/contribute.component.ts
+++ b/apps/erya/src/app/contribute/contribute.component.ts
@@ -21,7 +21,7 @@ import {
 } from '@angular/forms';
 import { UploadService } from './upload/upload.service';
 import { FaIconLibrary } from '@fortawesome/angular-fontawesome';
-import { faExternalLinkAlt, faUpload } from '@fortawesome/free-solid-svg-icons';
+import { faCheckCircle, faExclamationCircle, faExternalLinkAlt, faUpload } from '@fortawesome/free-solid-svg-icons';
 
 interface SensesFromApiSearchVariables {
   searchString?: string;
@@ -91,7 +91,7 @@ export class ContributeComponent implements OnInit, OnDestroy {
     private cd: ChangeDetectorRef,
     public library: FaIconLibrary
   ) {
-    library.addIcons(faExternalLinkAlt, faUpload);
+    library.addIcons(faExternalLinkAlt, faUpload, faCheckCircle, faExclamationCircle);
   }
 
   ngOnInit() {

--- a/apps/erya/src/app/contribute/contribute.component.ts
+++ b/apps/erya/src/app/contribute/contribute.component.ts
@@ -120,7 +120,8 @@ export class ContributeComponent implements OnInit, OnDestroy {
     this.senses$.subscribe(senses => {
       this.checkboxControl.clear();
       for (const _ of senses) {
-        this.checkboxControl.push(new FormControl(false));
+        const checkboxDefaultState = senses.length < 2;
+        this.checkboxControl.push(new FormControl(checkboxDefaultState));
       }
       this.senses = senses;
     });

--- a/apps/erya/src/assets/stylesheets/_main.scss
+++ b/apps/erya/src/assets/stylesheets/_main.scss
@@ -101,3 +101,10 @@ input.sense-input {
     width: 100%;
   }
 }
+
+.upload-sign-button {
+  .icon .loader {
+    border-bottom-color: $white;
+    border-left-color: $white;
+  }
+}


### PR DESCRIPTION
https://trello.com/c/WEUum5Xq/55-if-word-only-has-one-sense-select-it-automatically-and-dont-show-this-part-of-the-form-to-the-user
https://trello.com/c/ZEyEnLfB/54-inform-users-of-sign-upload-status

![Kapture 2020-03-20 at 19 03 38](https://user-images.githubusercontent.com/1761114/77188738-2210d080-6adf-11ea-8725-9638a459d363.gif)


@DerekHill This is initial Upload Statuses styles. Need to think more how we handle error e.g. show some help text, clear error if user changed file etc. Also what behaviour on success, should we redirect to sign after few second?
