### PR TITLE
Fix: Remove empty quotation marks

### DIFF
--- a/apps/erya/src/app/contribute/contribute.component.html
+++ b/apps/erya/src/app/contribute/contribute.component.html
@@ -115,10 +115,10 @@
                           sense.lexicalCategory
                         }}</span></span
                       >
-                      <span class="sense-example has-text-grey is-italic"
-                        >‘{{ sense.example }}’</span
+                      <span *ngIf="sense.example" class="sense-text-padding has-text-grey is-italic"
+                      >‘{{ sense.example }}’</span
                       >
-                      <span class="sense-definition ">
+                      <span [ngClass]="{'sense-definition': sense.example, 'sense-text-padding': !sense.example}">
                         {{ sense.definition }}</span
                       >
                     </label>

--- a/apps/erya/src/assets/stylesheets/_main.scss
+++ b/apps/erya/src/assets/stylesheets/_main.scss
@@ -37,7 +37,7 @@ youtube-player iframe,
 }
 
 .sense {
-  &-example {
+  &-text-padding {
     padding-top: 10px;
   }
   &-definition {


### PR DESCRIPTION
https://trello.com/c/aHhOLgUc/59-empty-quotation-marks-for-senses-with-out-example-example-and-definition-are-both-optional-but-we-only-show-senses-with-one-or-t

![image](https://user-images.githubusercontent.com/1761114/77253024-77c0b680-6c60-11ea-97d5-c90ca998d1ed.png)

![image](https://user-images.githubusercontent.com/1761114/77252876-7642be80-6c5f-11ea-959a-299c9f6e6a78.png)