### PR TITLE
Update: Consistent display of videos regardless of resolution

### DIFF
--- a/apps/erya/src/app/search/sign/sign.component.html
+++ b/apps/erya/src/app/search/sign/sign.component.html
@@ -1,4 +1,4 @@
-<figure  class="image" [ngClass]="{'is-16by9': !isRatioVertical, 'is-9by16': isRatioVertical}">
+<figure  class="image is-16by9" [ngStyle]="{'padding-top.%': paddingTop}">
   <video #videoSource autoplay loop playsinline [muted]="true" class="has-ratio" (loadedmetadata)="setRatio()" >
     <source
       src="{{mediaUrl}}"

--- a/apps/erya/src/app/search/sign/sign.component.html
+++ b/apps/erya/src/app/search/sign/sign.component.html
@@ -1,7 +1,9 @@
-<video autoplay loop playsinline [muted]="true">
-  <source
-    src="{{ mediaUrl }}"
-    (error)="onHtmlVideoError($event)"
-    type="video/mp4"
-  />
-</video>
+<figure  class="image" [ngClass]="{'is-16by9': !isRatioVertical, 'is-9by16': isRatioVertical}">
+  <video #videoSource autoplay loop playsinline [muted]="true" class="has-ratio" (loadedmetadata)="setRatio()" >
+    <source
+      src="{{mediaUrl}}"
+      (error)="onHtmlVideoError($event)"
+      type="video/mp4"
+    />
+  </video>
+</figure>

--- a/apps/erya/src/app/search/sign/sign.component.ts
+++ b/apps/erya/src/app/search/sign/sign.component.ts
@@ -21,7 +21,7 @@ export class SignComponent {
   public mediaUrl: string;
   private _sign: SignRecord;
 
-  isRatioVertical: boolean;
+  paddingTop: number;
 
   @HostListener('window:resize', ['$event'])
   onResize() {
@@ -77,11 +77,19 @@ export class SignComponent {
     const isVideoVertical =
       this.videoSource.nativeElement.videoHeight >
       this.videoSource.nativeElement.videoWidth;
-    const isWindowHighest =
-      window.innerHeight / window.innerWidth >
-      this.videoSource.nativeElement.videoHeight /
-        this.videoSource.nativeElement.videoWidth;
-    this.isRatioVertical =
-      isVideoVertical && isWindowHighest;
+    const isWindowHighest = window.innerHeight / window.innerWidth > 1;
+
+    if (isVideoVertical) {
+      const headerAndFooterHeight = 300;
+      const optimalPadding = 70;
+
+      if (isWindowHighest) {
+        this.paddingTop =
+          ((window.innerHeight - headerAndFooterHeight) / window.innerWidth) *
+          100;
+      } else {
+        this.paddingTop = optimalPadding;
+      }
+    }
   }
 }

--- a/apps/erya/src/app/search/sign/sign.component.ts
+++ b/apps/erya/src/app/search/sign/sign.component.ts
@@ -1,4 +1,10 @@
-import { Component, Input } from '@angular/core';
+import {
+  Component,
+  ElementRef,
+  HostListener,
+  Input,
+  ViewChild
+} from '@angular/core';
 import { SignRecord, Transcoding } from '@edfu/api-interfaces';
 import { DeviceDetectorService } from 'ngx-device-detector';
 import { FaIconLibrary } from '@fortawesome/angular-fontawesome';
@@ -10,8 +16,17 @@ import { CDN_URI } from '../../constants';
   templateUrl: './sign.component.html'
 })
 export class SignComponent {
+  @ViewChild('videoSource') videoSource: ElementRef;
+
   public mediaUrl: string;
   private _sign: SignRecord;
+
+  isRatioVertical: boolean;
+
+  @HostListener('window:resize', ['$event'])
+  onResize() {
+    this.setRatio();
+  }
 
   constructor(
     private deviceService: DeviceDetectorService,
@@ -56,5 +71,17 @@ export class SignComponent {
     } else {
       return 1;
     }
+  }
+
+  setRatio() {
+    const isVideoVertical =
+      this.videoSource.nativeElement.videoHeight >
+      this.videoSource.nativeElement.videoWidth;
+    const isWindowHighest =
+      window.innerHeight / window.innerWidth >
+      this.videoSource.nativeElement.videoHeight /
+        this.videoSource.nativeElement.videoWidth;
+    this.isRatioVertical =
+      isVideoVertical && isWindowHighest;
   }
 }


### PR DESCRIPTION
https://trello.com/c/LhrDGfFe/68-consistent-display-of-videos-regardless-of-resolution
https://trello.com/c/0fr2spSN/74-propose-desktop-transcoding

We check If video is portrait and update styles based on this.
![image](https://user-images.githubusercontent.com/1761114/78780411-3857d100-79a7-11ea-8d58-5d53fa0ede8a.png)

![image](https://user-images.githubusercontent.com/1761114/78780521-6f2de700-79a7-11ea-8754-f92b3e29ac33.png)

Portrait video fit height on mobile, header and footer stay visible to user
![image](https://user-images.githubusercontent.com/1761114/78780614-91c00000-79a7-11ea-9f0a-48c0eee1e723.png)
